### PR TITLE
fix: don't hold the pin lock while updating pins

### DIFF
--- a/pin.go
+++ b/pin.go
@@ -526,7 +526,11 @@ func (p *pinner) Update(ctx context.Context, from, to cid.Cid, unpin bool) error
 		return fmt.Errorf("'from' cid was not recursively pinned already")
 	}
 
+	// Temporarily unlock while we fetch the differences.
+	p.lock.Unlock()
 	err := dagutils.DiffEnumerate(ctx, p.dserv, from, to)
+	p.lock.Lock()
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
fixes https://github.com/ipfs/go-ipfs/issues/6885