### PR TITLE
Define ErrNotPinned alongside the Pinner interface

### DIFF
--- a/dspinner/pin.go
+++ b/dspinner/pin.go
@@ -31,9 +31,6 @@ const (
 )
 
 var (
-	// ErrNotPinned is returned when trying to unpin items that are not pinned.
-	ErrNotPinned = errors.New("not pinned or pinned indirectly")
-
 	log logging.StandardLogger = logging.Logger("pin")
 
 	linkDirect, linkRecursive string
@@ -346,7 +343,7 @@ func (p *pinner) Unpin(ctx context.Context, c cid.Cid, recursive bool) error {
 			return err
 		}
 		if !has {
-			return ErrNotPinned
+			return ipfspinner.ErrNotPinned
 		}
 	}
 

--- a/dspinner/pin_test.go
+++ b/dspinner/pin_test.go
@@ -260,8 +260,8 @@ func TestPinnerBasic(t *testing.T) {
 	}
 
 	err = p.Unpin(ctx, dk, true)
-	if err != ErrNotPinned {
-		t.Fatal("expected error:", ErrNotPinned)
+	if err != ipfspin.ErrNotPinned {
+		t.Fatal("expected error:", ipfspin.ErrNotPinned)
 	}
 
 	err = p.Flush(ctx)

--- a/pin.go
+++ b/pin.go
@@ -75,6 +75,9 @@ func StringToMode(s string) (Mode, bool) {
 	return mode, ok
 }
 
+// ErrNotPinned is returned when trying to unpin items that are not pinned.
+var ErrNotPinned = fmt.Errorf("not pinned or pinned indirectly")
+
 // A Pinner provides the necessary methods to keep track of Nodes which are
 // to be kept locally, according to a pin mode. In practice, a Pinner is in
 // in charge of keeping the list of items from the local storage that should
@@ -93,6 +96,7 @@ type Pinner interface {
 
 	// Unpin the given cid. If recursive is true, removes either a recursive or
 	// a direct pin. If recursive is false, only removes a direct pin.
+	// If the pin doesn't exist, return ErrNotPinned
 	Unpin(ctx context.Context, cid cid.Cid, recursive bool) error
 
 	// Update updates a recursive pin from one cid to another


### PR DESCRIPTION
Allows for alternative implementation with the same error being part of the interface contract.