### PR TITLE
change the Pinner interface to have async pin listing

### DIFF
--- a/dspinner/pin_test.go
+++ b/dspinner/pin_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Jorropo/channel"
 	bs "github.com/ipfs/go-blockservice"
 	mdag "github.com/ipfs/go-merkledag"
 
@@ -199,12 +200,16 @@ func TestPinnerBasic(t *testing.T) {
 	dk := d.Cid()
 	assertPinned(t, p, dk, "pinned node not found.")
 
-	allCids := func(c <-chan ipfspin.StreamedCid) (cids []cid.Cid) {
-		for streamedCid := range c {
-			if streamedCid.Err != nil {
-				t.Fatal(streamedCid.Err)
+	allCids := func(ch channel.ReadOnly[cid.Cid]) (cids []cid.Cid) {
+		for {
+			c, err := ch.Read()
+			if err == io.EOF {
+				break
 			}
-			cids = append(cids, streamedCid.Cid)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cids = append(cids, c)
 		}
 		return cids
 	}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ipfs/go-ipfs-pinner
 go 1.19
 
 require (
+	github.com/Jorropo/channel v0.0.0-20230303124104-2821e25e07ff
 	github.com/ipfs/go-blockservice v0.2.1
 	github.com/ipfs/go-cid v0.0.7
 	github.com/ipfs/go-datastore v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96 h1:cTp8I5+VIo
 github.com/AndreasBriese/bbloom v0.0.0-20190825152654-46b345b51c96/go.mod h1:bOvUY6CB00SOBii9/FifXqc0awNKxLFCL/+pkDPuyl8=
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/Jorropo/channel v0.0.0-20230303124104-2821e25e07ff h1:esIsTO+B4ChRmGN1F2NQXe3y1zV6+VtW5q2NfiKKptc=
+github.com/Jorropo/channel v0.0.0-20230303124104-2821e25e07ff/go.mod h1:mI95Zfa5HM2woyGuaxl2tTnfZKKzPAyjwcbvmMk7hwI=
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Kubuxu/go-os-helper v0.0.1/go.mod h1:N8B+I7vPCT80IcP58r50u4+gEEcsZETFUpAzWW2ep1Y=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=

--- a/pin.go
+++ b/pin.go
@@ -80,7 +80,7 @@ var ErrNotPinned = fmt.Errorf("not pinned or pinned indirectly")
 
 // A Pinner provides the necessary methods to keep track of Nodes which are
 // to be kept locally, according to a pin mode. In practice, a Pinner is in
-// in charge of keeping the list of items from the local storage that should
+// charge of keeping the list of items from the local storage that should
 // not be garbage-collected.
 type Pinner interface {
 	// IsPinned returns whether or not the given cid is pinned
@@ -119,14 +119,21 @@ type Pinner interface {
 	Flush(ctx context.Context) error
 
 	// DirectKeys returns all directly pinned cids
-	DirectKeys(ctx context.Context) ([]cid.Cid, error)
+	DirectKeys(ctx context.Context) <-chan StreamedCid
 
 	// RecursiveKeys returns all recursively pinned cids
-	RecursiveKeys(ctx context.Context) ([]cid.Cid, error)
+	RecursiveKeys(ctx context.Context) <-chan StreamedCid
 
 	// InternalPins returns all cids kept pinned for the internal state of the
 	// pinner
-	InternalPins(ctx context.Context) ([]cid.Cid, error)
+	InternalPins(ctx context.Context) <-chan StreamedCid
+}
+
+// StreamedCid is a cid.Cid that carries an error, to be sent through a channel.
+type StreamedCid struct {
+	// if not nil, an error happened. Everything else should be ignored.
+	Err error
+	Cid cid.Cid
 }
 
 // Pinned represents CID which has been pinned with a pinning strategy.

--- a/pin.go
+++ b/pin.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/Jorropo/channel"
 	cid "github.com/ipfs/go-cid"
 	ipld "github.com/ipfs/go-ipld-format"
 )
@@ -119,21 +120,14 @@ type Pinner interface {
 	Flush(ctx context.Context) error
 
 	// DirectKeys returns all directly pinned cids
-	DirectKeys(ctx context.Context) <-chan StreamedCid
+	DirectKeys(ctx context.Context) channel.ReadOnly[cid.Cid]
 
 	// RecursiveKeys returns all recursively pinned cids
-	RecursiveKeys(ctx context.Context) <-chan StreamedCid
+	RecursiveKeys(ctx context.Context) channel.ReadOnly[cid.Cid]
 
 	// InternalPins returns all cids kept pinned for the internal state of the
 	// pinner
-	InternalPins(ctx context.Context) <-chan StreamedCid
-}
-
-// StreamedCid is a cid.Cid that carries an error, to be sent through a channel.
-type StreamedCid struct {
-	// if not nil, an error happened. Everything else should be ignored.
-	Err error
-	Cid cid.Cid
+	InternalPins(ctx context.Context) channel.ReadOnly[cid.Cid]
 }
 
 // Pinned represents CID which has been pinned with a pinning strategy.


### PR DESCRIPTION
The rational is that if the pin list get big, a synchronous call to get the complete list can delay handling unnecessarily. For example, when listing indirect pins, you can start walking the DAGs immediately with the first recursive pin instead of waiting for the full list.

This matters even more on low power device, of if the pin list is stored remotely.

Corresponding Kubo PR: https://github.com/ipfs/kubo/pull/9692